### PR TITLE
Add overlay_size option

### DIFF
--- a/dracut/90overlay-root/overlay-mount.sh
+++ b/dracut/90overlay-root/overlay-mount.sh
@@ -24,7 +24,10 @@ umount $NEWROOT
 
 # Create tmpfs
 mkdir /cow
-mount -n -t tmpfs -o mode=0755 tmpfs /cow
+if [[ ! -z $(getarg overlay_size=) ]] ; then
+    RAMDISK_OPT=",size=$(getarg overlay_size=)"
+fi
+mount -n -t tmpfs -o mode=0755$RAMDISK_OPT tmpfs /cow
 mkdir /cow/work /cow/rw
 
 # Merge both to new Filesystem


### PR DESCRIPTION
root size can be set by overlay_size kernel option instead of 50% of
the RAM by default.
Example:
VM 28GB RAM
without overlay_size
Filesystem      Size  Used Avail Use% Mounted on
overlay          14G   65M   14G   1% /

Filesystem      Size  Used Avail Use% Mounted on
with overlay_size=1G
overlay         1.0G   65M  960M   7% /